### PR TITLE
fix: use the correct data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,7 @@ hianime
     {
       lang: "English",
       url: string, // .vtt subtitle file
+      default: boolean,
     },
     {...}
   ],

--- a/src/extractors/megacloud.ts
+++ b/src/extractors/megacloud.ts
@@ -505,7 +505,6 @@ class MegaCloud {
                 isM3U8: s.type === "hls",
                 type: s.type,
             }));
-			console.log(extractedData);
 
             return extractedData;
         } catch (err){


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Currently the `getAnimeEpisodeSources` method doesn't return the same data structure given in the documentation.
I also added the `default` property to subtitles.

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

Yes, I added the `default` property to the `getAnimeEpisodeSources` method.

**Summary**

Currently the method returns a different data structure than given in the documentation, this pr aims for consistency.

**Other information**
